### PR TITLE
chore(infra): add healthcheck for LiteLLM proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
       LITELLM_LOG: info
     command: ["--host", "0.0.0.0", "--port", "4000"]
     healthcheck:
-      # Prefer Python-based HTTP check to avoid requiring curl/wget in the image
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0) if urllib.request.urlopen('http://localhost:4000/', timeout=2).status < 500 else sys.exit(1)"]
+      # Use LiteLLM official health endpoint
+      test: ["CMD", "python", "-c", "import urllib.request,sys; r=urllib.request.urlopen('http://localhost:4000/health', timeout=3); sys.exit(0) if r.status==200 else sys.exit(1)"]
       interval: 15s
       timeout: 5s
       start_period: 10s
@@ -78,7 +78,7 @@ services:
       postgres:
         condition: service_healthy
       litellm:
-        condition: service_started
+        condition: service_healthy
 
   dagster-webserver:
     build:
@@ -107,7 +107,7 @@ services:
       dagster-daemon:
         condition: service_started
       litellm:
-        condition: service_started
+        condition: service_healthy
 
   web:
     build:


### PR DESCRIPTION
This PR adds a healthcheck to the LiteLLM proxy service in docker-compose.yml.

Why:
- Ensures the proxy is responsive before dependent services start
- Improves reliability and observability per #147 epic

What changed:
- Healthcheck now uses the official LiteLLM endpoint `GET http://localhost:4000/health` per docs
- Reasonable defaults: interval=15s, timeout=5s, start_period=10s, retries=5
- dagster-daemon and dagster-webserver now wait for LiteLLM to be healthy (depends_on: service_healthy)

Testing:
- Manual: `docker compose up litellm` and observe the service becomes healthy once `/health` returns 200
- With the new depends_on, dagster services will start after LiteLLM is healthy

Docs:
- https://docs.litellm.ai/docs/proxy/health

Closes #168

Agent checklist:
- No API behavior changes
- No ingestion behavior changes
- No UI under web/** modified
- No dependency changes
- Targeted change only to compose config
- No tests added (config-only change)
